### PR TITLE
fix: Git icons not staying in the right gutter

### DIFF
--- a/lua/fyler/extensions/git.lua
+++ b/lua/fyler/extensions/git.lua
@@ -193,14 +193,13 @@ extensions.register({
     config.extensions.git = vim.tbl_deep_extend('force', { icons = vim.deepcopy(default_icons), inline = true }, opts)
   end,
   hooks = {
-    finder_refresh_post = function(inst, visible, hl_ns, lines, args)
+    finder_refresh_post = function(inst, visible, hl_ns, _lines, args)
       local cfg = require('fyler.config').DATA.extensions.git
       if not cfg.enabled then return end
 
       refresh_count = refresh_count + 1
       local current_count = refresh_count
 
-      local gc = H.git_col(lines)
       local function apply(i, item, stat)
         local icon, hl = H.get_icon(stat, cfg.icons)
         if not hl then return end
@@ -221,7 +220,7 @@ extensions.register({
               hl_ns,
               i - 1,
               0,
-              { virt_text = { { icon, hl } }, virt_text_win_col = gc, hl_mode = 'combine' }
+              { virt_text = { { icon, hl } }, virt_text_pos = 'right_align', hl_mode = 'combine' }
             )
           end
         end


### PR DESCRIPTION
Fixes: #323 

Updates it so the git icons align to the right

[Screencast_20260704_001503.webm](https://github.com/user-attachments/assets/b98d81e1-5bff-44a6-bef6-8a3a0ddb449c)
