### PR TITLE
fix: Watcher not updating on file change

### DIFF
--- a/lua/fyler/extensions/git.lua
+++ b/lua/fyler/extensions/git.lua
@@ -195,12 +195,13 @@ extensions.register({
     config.extensions.git = vim.tbl_deep_extend('force', { icons = vim.deepcopy(default_icons), inline = true }, opts)
   end,
   hooks = {
-    finder_refresh_post = function(inst, visible, hl_ns, lines, args)
+    finder_refresh_post = function(inst, visible, _, lines, args)
       local cfg = require('fyler.config').DATA.extensions.git
       if not cfg.enabled then return end
 
       refresh_count = refresh_count + 1
       local current_count = refresh_count
+      local git_ns = vim.api.nvim_create_namespace('FylerGitBuf' .. inst.buf_id)
 
       local gc = H.git_col(lines)
       local function apply(i, item, stat)
@@ -211,7 +212,7 @@ extensions.register({
             pcall(
               vim.api.nvim_buf_set_extmark,
               inst.buf_id,
-              hl_ns,
+              git_ns,
               i - 1,
               item._name_col + #item.name,
               { virt_text = { { icon, hl } }, hl_mode = 'combine' }
@@ -220,7 +221,7 @@ extensions.register({
             pcall(
               vim.api.nvim_buf_set_extmark,
               inst.buf_id,
-              hl_ns,
+              git_ns,
               i - 1,
               0,
               { virt_text = { { icon, hl } }, virt_text_win_col = gc, hl_mode = 'combine' }
@@ -230,20 +231,29 @@ extensions.register({
         pcall(
           vim.api.nvim_buf_set_extmark,
           inst.buf_id,
-          hl_ns,
+          git_ns,
           i - 1,
           item._name_col,
           { hl_group = hl, end_line = i - 1, end_col = item._name_col + #item.name, hl_mode = 'combine' }
         )
       end
+
+      local function render(statuses)
+        pcall(vim.api.nvim_buf_clear_namespace, inst.buf_id, git_ns, 0, -1)
+        for i, item in ipairs(visible) do
+          local stat = statuses[item.path]
+          if stat then apply(i, item, stat) end
+        end
+      end
+
+      render(inst.cache.git_statuses or {})
+
       H.statuses_async(visible, args and args.force, function(statuses)
         if current_count == refresh_count then
           H.propagate_to_parents(statuses)
           H.store_known_roots()
-          for i, item in ipairs(visible) do
-            local stat = statuses[item.path]
-            if stat then apply(i, item, stat) end
-          end
+          inst.cache.git_statuses = statuses
+          render(statuses)
         end
       end)
     end,

--- a/lua/fyler/extensions/git.lua
+++ b/lua/fyler/extensions/git.lua
@@ -21,6 +21,8 @@ local default_icons = {
   [' M'] = { icon = '*', hl = 'FylerGitModified' },
   ['M '] = { icon = '+', hl = 'FylerGitStaged' },
   ['MM'] = { icon = '+', hl = 'FylerGitStaged' },
+  ['A '] = { icon = '+', hl = 'FylerGitStaged' },
+  ['AM'] = { icon = '+', hl = 'FylerGitStaged' },
   ['??'] = { icon = '?', hl = 'FylerGitUntracked' },
   [' D'] = { icon = '-', hl = 'FylerGitDeleted' },
   ['D '] = { icon = '-', hl = 'FylerGitStaged' },

--- a/lua/fyler/extensions/watcher.lua
+++ b/lua/fyler/extensions/watcher.lua
@@ -17,7 +17,7 @@ function H.start_handle(buf_id, dir_path, on_event)
   local handle = uv.new_fs_event()
   if not handle then return end
 
-  local ok = handle:start(dir_path, { watch_entry = true }, function(err, filename, status)
+  local ok = handle:start(dir_path, {}, function(err, filename, status)
     if err then return end
     on_event(filename, status)
   end)
@@ -113,7 +113,7 @@ extensions.register({
           local is_git_dir = dir_path:match('/%.git$')
           H.start_handle(buf_id, dir_path, function(filename, status)
             if is_git_dir and filename and not (filename == 'index') then return end
-            if not is_git_dir and not (status and status.rename) then return end
+            if not is_git_dir and not (status and (status.rename or status.change)) then return end
 
             if is_git_dir then
               state.pending_refresh = { force = true, recursive = true }

--- a/lua/fyler/extensions/watcher.lua
+++ b/lua/fyler/extensions/watcher.lua
@@ -112,7 +112,7 @@ extensions.register({
         if not state.handles[dir_path] then
           local is_git_dir = dir_path:match('/%.git$')
           H.start_handle(buf_id, dir_path, function(filename, status)
-            if is_git_dir and filename and not (filename == 'index') then return end
+            if is_git_dir and filename and not (filename == 'index' or filename == 'index.lock') then return end
             if not is_git_dir and not (status and (status.rename or status.change)) then return end
 
             if is_git_dir then
@@ -126,7 +126,11 @@ extensions.register({
             state.timer:start(cfg.debounce_ms, 0, function()
               vim.schedule(function()
                 if not watch_state[buf_id] then return end
+                if vim.bo[buf_id].modified then return end
+
                 local pending = state.pending_refresh
+                state.pending_refresh = nil
+
                 pcall(function() instance:refresh(pending) end)
               end)
             end)


### PR DESCRIPTION
Currently the watcher doesn't always update the git status without reopening fyler, I mostly noticed this when editing files or adding new files.

Before:
[Screencast_20260704_133548.webm](https://github.com/user-attachments/assets/5abdd479-8b66-4ff7-b48c-d726461f95a4)

After:
[Screencast_20260704_133913.webm](https://github.com/user-attachments/assets/5c5e103d-f055-4fb5-a66b-74bb760225a8)
