### PR TITLE
[FIX] render tree when root is a dotfile directory

### DIFF
--- a/lua/fyler/state.lua
+++ b/lua/fyler/state.lua
@@ -169,7 +169,9 @@ function M.new(root_path, scheme)
       local data = M.store[node.value]
       if not data then return end
 
-      if opts.skip_hidden and libfs.is_hidden(data.path, opts.hidden_items) then return end
+      -- The root node is never rendered and must not be filtered by hidden items,
+      -- otherwise a dotfile root (e.g. ~/.config) would skip the whole subtree.
+      if depth > 0 and opts.skip_hidden and libfs.is_hidden(data.path, opts.hidden_items) then return end
 
       callback(node, depth)
 

--- a/tests/integrations/finder.test.lua
+++ b/tests/integrations/finder.test.lua
@@ -26,6 +26,17 @@ T['Finder with kind']['can render entries'] = function(kind)
   n.expect_screenshot()
 end
 
+T['Finder with kind']['can render entries from dotfile root'] = function(kind)
+  local tmpdir = helper.get_tmpdir('.hidden-root', { 'a-dir/', 'a-file' })
+  n.fwd_lua('require("fyler").setup')({})
+  n.fwd_lua('require("fyler").open')({ kind = kind, root_path = tmpdir })
+  vim.uv.sleep(10)
+  local lines = n.api.nvim_buf_get_lines(0, 0, -1, false)
+  helper.expect.equality(#lines, 2)
+  helper.expect.match(table.concat(lines, '\n'), 'a-dir')
+  helper.expect.match(table.concat(lines, '\n'), 'a-file')
+end
+
 T['Finder with kind']['can expand directory'] = function(kind)
   local tmpdir = helper.get_tmpdir('data', { 'a-dir/', 'a-dir/aa-file' })
   n.fwd_lua('require("fyler").setup')({})


### PR DESCRIPTION
## Summary

When opening Fyler with a dotfile directory as the root (e.g. `/home/lavinraj/.config`, `~/.cache`, `~/.local`), the buffer rendered nothing.

## Root cause

`state:walk` applied the hidden-items filter to the root node itself. With the default `dotfiles` switch enabled, any path whose basename starts with `.` is hidden — so a root like `~/.config` was considered hidden, and the `return` fired before recursing into children, skipping the entire subtree. `to_lines()` then returned `{}` and nothing was rendered.

## Fix

Exempt the root node (`depth == 0`) from the hidden check in `lua/fyler/state.lua`. The root is never rendered anyway (`to_lines` skips depth 0), so this only restores recursion into children.

## Tests

- Added regression test `can render entries from dotfile root` (runs for all 10 window kinds)
- Full suite passes: 330/330
- selene + stylua clean